### PR TITLE
Added Windows Support #

### DIFF
--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -96,7 +96,7 @@ local function init()
 		return
 	end
 
-	if system == "Linux" or system == "Darwin" then
+	if vim.fn.has("unix") then
 		if vim.loop.getuid() == 0 then
 			query_command = "su - $SUDO_USER -c " .. query_command
 		end


### PR DESCRIPTION
https://github.com/f-person/auto-dark-mode.nvim/assets/25822972/a063c9d4-d601-48fb-b768-bb76b14e05de

@f-person This pull request fixes #9. I have provided a demo to show the theme changes when the system theme is manually changed using [AutoDarkMode](https://github.com/AutoDarkMode/Windows-Auto-Night-Mode) on Windows 11. 

The default shell in Neovim on Windows is Command Prompt. Therefore, the `query_command` I have used is `'Reg Query "HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize" /v AppsUseLightTheme | findstr "AppsUseLightTheme"'` and swapping the single and double quotes breaks the logic; command prompt seems quite picky about quotation marks.