### PR TITLE
feat: make `query_command` shell-agnostic

### DIFF
--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -126,10 +126,9 @@ local function init()
 				query_command = vim.tbl_extend("keep", { "su", "-", sudo_user, "-c" }, query_command)
 			else
 				error([[
-        auto-dark-mode.nvim:
-
-        Running as `root`, but `$SUDO_USER` is not set.
-        Please open an issue to add support for your system.
+				auto-dark-mode.nvim:
+				Running as `root`, but `$SUDO_USER` is not set.
+				Please open an issue to add support for your system.
 				]])
 			end
 		end

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -85,14 +85,17 @@ local function init()
 	  ]])
 		end
 
-		query_command = vim.tbl_extend("keep", {
-			"dbus-send --session --print-reply=literal --reply-timeout=1000",
+		query_command = {
+			"dbus-send",
+			"--session",
+			"--print-reply=literal",
+			"--reply-timeout=1000",
 			"--dest=org.freedesktop.portal.Desktop",
 			"/org/freedesktop/portal/desktop",
 			"org.freedesktop.portal.Settings.Read",
 			"string:'org.freedesktop.appearance'",
 			"string:'color-scheme'",
-		})
+		}
 	elseif system == "Windows_NT" or system == "WSL" then
 		-- Don't swap the quotes; it breaks the code
 		query_command = {

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -121,7 +121,17 @@ local function init()
 	if vim.fn.has("unix") ~= 0 then
 		if vim.loop.getuid() == 0 then
 			local sudo_user = vim.env.SUDO_USER
-			query_command = vim.tbl_extend("keep", { "su", "-", sudo_user, "-c" }, query_command)
+
+			if sudo_user ~= nil then
+				query_command = vim.tbl_extend("keep", { "su", "-", sudo_user, "-c" }, query_command)
+			else
+				error([[
+          auto-dark-mode.nvim:
+
+          Running as `root`, but `$SUDO_USER` is not set.
+          Please open an issue to add support for your system.
+        ]])
+			end
 		end
 	end
 

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -95,15 +95,20 @@ local function init()
 		})
 	elseif system == "Windows_NT" or system == "WSL" then
 		-- Don't swap the quotes; it breaks the code
-		query_command =
-			{ "reg.exe", "Query", "HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", "/v", "AppsUseLightTheme" }
+		query_command = {
+			"reg.exe",
+			"Query",
+			"HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+			"/v",
+			"AppsUseLightTheme",
+		}
 	else
 		return
 	end
 
 	if vim.fn.has("unix") ~= 0 then
 		if vim.loop.getuid() == 0 then
-			query_command = vim.tbl_extend("keep", { "su", "-", "$SUDO_USER", "-c"  } , query_command)
+			query_command = vim.tbl_extend("keep", { "su", "-", "$SUDO_USER", "-c" }, query_command)
 		end
 	end
 

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -111,7 +111,8 @@ local function init()
 
 	if vim.fn.has("unix") ~= 0 then
 		if vim.loop.getuid() == 0 then
-			query_command = vim.tbl_extend("keep", { "su", "-", "$SUDO_USER", "-c" }, query_command)
+			local sudo_user = vim.env.SUDO_USER
+			query_command = vim.tbl_extend("keep", { "su", "-", sudo_user, "-c" }, query_command)
 		end
 	end
 

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -40,8 +40,8 @@ local function parse_query_response(res)
 	elseif system == "Darwin" then
 		return res[1] == "Dark"
 	elseif system == "Windows_NT" or system == "WSL" then
-		-- AppsUseLightTheme    REG_DWORD    0x0 : dark
-		-- AppsUseLightTheme    REG_DWORD    0x1 : light
+		-- AppsUseLightTheme REG_DWORD 0x0 : dark
+		-- AppsUseLightTheme REG_DWORD 0x1 : light
 		return string.match(res[3], "0x1") == nil
 	end
 	return false
@@ -91,7 +91,7 @@ local function init()
 			error([[
 		`dbus-send` is not available. The Linux implementation of
 		auto-dark-mode.nvim relies on `dbus-send` being on the `$PATH`.
-	  ]])
+		]])
 		end
 
 		query_command = {
@@ -126,11 +126,11 @@ local function init()
 				query_command = vim.tbl_extend("keep", { "su", "-", sudo_user, "-c" }, query_command)
 			else
 				error([[
-          auto-dark-mode.nvim:
+        auto-dark-mode.nvim:
 
-          Running as `root`, but `$SUDO_USER` is not set.
-          Please open an issue to add support for your system.
-        ]])
+        Running as `root`, but `$SUDO_USER` is not set.
+        Please open an issue to add support for your system.
+				]])
 			end
 		end
 	end

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -93,8 +93,8 @@ local function init()
 			"--dest=org.freedesktop.portal.Desktop",
 			"/org/freedesktop/portal/desktop",
 			"org.freedesktop.portal.Settings.Read",
-			"string:'org.freedesktop.appearance'",
-			"string:'color-scheme'",
+			"string:org.freedesktop.appearance",
+			"string:color-scheme",
 		}
 	elseif system == "Windows_NT" or system == "WSL" then
 		-- Don't swap the quotes; it breaks the code

--- a/lua/auto-dark-mode/utils.lua
+++ b/lua/auto-dark-mode/utils.lua
@@ -1,6 +1,6 @@
 local M = {}
 
----@param cmd string
+---@param cmd table
 ---@param opts {input?: string, on_stdout?: function, on_exit?: function}
 ---@return number | 'the job id'
 function M.start_job(cmd, opts)


### PR DESCRIPTION
fixes #18
`query_command` is now of type `table` so that `vim.fn.jobstart` does
not use `shell`.

Tested on Windows 11 with nushell.
Needs testing in:
* linux
* linux + sudo
* macos
* WSL

The code in `parse_query_response` now needs to handle a table, instead of a string, because the `query_command` cannot use pipes any more, which previously guaranteed that stdout consisted of one line.