### PR TITLE
Add warning about low `update_interval` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ You need to call `setup` for initialization.
 By default, they just change the background option, but you can do whatever you like.
 
 `update_interval` is how frequently the system appearance is checked.
-The value is stored in milliseconds. Defaults to `3000`.
+The value needs to be larger than whatever time your system takes to query dark mode.
+Otherwise you risk freezing neovim on shutdown.
+The value is stored in milliseconds.
+Defaults to `3000`.
 
 ```lua
 local auto_dark_mode = require('auto-dark-mode')

--- a/doc/auto-dark-mode.txt
+++ b/doc/auto-dark-mode.txt
@@ -46,8 +46,9 @@ options – `set_dark_mode` function, `set_light_mode` function, and
 change the background option, but you can do whatever you like.
 
 `update_interval` is how frequently the system appearance is checked. The value
-is stored in milliseconds. Defaults to `3000`.
-
+is stored in milliseconds. Take care to choose a value, that is larger than
+the time needed to query the system appearance. A value lower than that might
+cause Neovim to freeze. Defaults to `3000`.
 >lua
     local auto_dark_mode = require('auto-dark-mode')
     


### PR DESCRIPTION
fix #20

Adds a warning to the README and help files about `update_interval`
values, that are lower then wall time of `query_command`, as that might
freeze Neovim on shutdown.
