### PR TITLE
Readme: Remove deprecated "config" table input for "opts"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ auto_dark_mode.setup({
 ```lua
 return {
   "f-person/auto-dark-mode.nvim",
-  config = {
+  opts = {
     update_interval = 1000,
     set_dark_mode = function()
       vim.api.nvim_set_option("background", "dark")


### PR DESCRIPTION
Title. "config" is deprecated for the Lazy NeoVim plugin manager. Switched to "opts". Tested and works on my setup.