### PR TITLE
Use `nvim_set_option_value` in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ local auto_dark_mode = require('auto-dark-mode')
 auto_dark_mode.setup({
 	update_interval = 1000,
 	set_dark_mode = function()
-		vim.api.nvim_set_option('background', 'dark')
+		vim.api.nvim_set_option_value('background', 'dark', {})
 		vim.cmd('colorscheme gruvbox')
 	end,
 	set_light_mode = function()
-		vim.api.nvim_set_option('background', 'light')
+		vim.api.nvim_set_option_value('background', 'light', {})
 		vim.cmd('colorscheme gruvbox')
 	end,
 })
@@ -81,11 +81,11 @@ return {
   opts = {
     update_interval = 1000,
     set_dark_mode = function()
-      vim.api.nvim_set_option("background", "dark")
+      vim.api.nvim_set_option_value("background", "dark", {})
       vim.cmd("colorscheme gruvbox")
     end,
     set_light_mode = function()
-      vim.api.nvim_set_option("background", "light")
+      vim.api.nvim_set_option_value("background", "light", {})
       vim.cmd("colorscheme gruvbox")
     end,
   },


### PR DESCRIPTION
This updates the readme to use `nvim_set_option_value` since `nvim_set_option` is deprecated.