### PR TITLE
feat: Add `default` option for fallback theme

### DIFF
--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -19,7 +19,7 @@ local query_command
 local system
 
 ---@type "light" | "dark"
-local default_theme;
+local fallback;
 
 -- Parses the query response for each system
 ---@param res string
@@ -35,7 +35,7 @@ local function parse_query_response(res)
 		elseif string.match(res, "unit32 2") ~= nil then
 			return false
 		else
-			return default_theme == "dark"
+			return fallback == "dark"
 		end
 	elseif system == "Darwin" then
 		return res == "Dark"
@@ -158,7 +158,7 @@ local function setup(options)
 		set_background("light")
 	end
 	update_interval = options.update_interval or 3000
-	default_theme = options.default or "dark"
+	fallback = options.fallback or "dark"
 
 	init()
 end

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -18,6 +18,9 @@ local query_command
 ---@type "Linux" | "Darwin" | "Windows_NT" | "WSL"
 local system
 
+---@type "light" | "dark"
+local default_theme;
+
 -- Parses the query response for each system
 ---@param res string
 ---@return boolean
@@ -27,7 +30,13 @@ local function parse_query_response(res)
 		-- 0: no preference
 		-- 1: dark
 		-- 2: light
-		return string.match(res, "uint32 1") ~= nil
+		if string.match(res, "uint32 1") ~= nil then
+			return true
+		elseif string.match(res, "unit32 2") ~= nil then
+			return false
+		else
+			return default_theme == "dark"
+		end
 	elseif system == "Darwin" then
 		return res == "Dark"
 	elseif system == "Windows_NT" or system == "WSL" then
@@ -149,6 +158,7 @@ local function setup(options)
 		set_background("light")
 	end
 	update_interval = options.update_interval or 3000
+	default_theme = options.default or "dark"
 
 	init()
 end

--- a/lua/auto-dark-mode/types.lua
+++ b/lua/auto-dark-mode/types.lua
@@ -5,6 +5,6 @@
 ---@field set_light_mode nil | fun(): nil
 -- Every `update_interval` milliseconds a theme check will be performed.
 ---@field update_interval number?
--- Optional. Default theme to use if the system theme can't be detected. 
+-- Optional. Fallback theme to use if the system theme can't be detected. 
 -- Useful for linux and environments without a desktop manager.
----@field default "light" | "dark" | nil
+---@field fallback "light" | "dark" | nil

--- a/lua/auto-dark-mode/types.lua
+++ b/lua/auto-dark-mode/types.lua
@@ -5,3 +5,6 @@
 ---@field set_light_mode nil | fun(): nil
 -- Every `update_interval` milliseconds a theme check will be performed.
 ---@field update_interval number?
+-- Optional. Default theme to use if the system theme can't be detected. 
+-- Useful for linux and environments without a desktop manager.
+---@field default "light" | "dark" | nil


### PR DESCRIPTION
This PR adds a default option that is used in case the system theme is not detected (before it got set to light mode, which I suspect is not usually the desired behaviour). This only applies to Linux since, afaict, macOS and Windows always have some option enabled. 

This is useful in desktop-less environments (e.g., a server) and some linux environments (e.g., it was unclear to me how to set it up in Hyprland).

In my case, I was using this plugin on my macOS setup and it worked perfectly, then I tried it on a server to edit files locally and it blasted me with light mode so I had to disable it. Then I installed Linux with Hyprland and it was hard to figure out how to set the xorg setting, so I had to also disable it there. This PR will hopefully help with neovim setups that work consistently across the board! 😁

The `default` option name might need a bit of bikeshedding. Potential alternatives are `default_theme` (which I don’t particularly like) and `fallback` (which I do like). Feel free to use whichever you prefer :)

Also, docs need to be written and perhaps the README needs to be updated. However, I'm not sure exactly where they would go since there is not the usual "configuration" section in neither. 