### PR TITLE
Swapped the reg.exe parameter of query_command to its absolute path

### DIFF
--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -108,7 +108,7 @@ local function init()
 	elseif system == "Windows_NT" or system == "WSL" then
 		-- Don't swap the quotes; it breaks the code
 		query_command = {
-			"reg.exe",
+			"/mnt/c/Windows/System32/reg.exe",
 			"Query",
 			"HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
 			"/v",


### PR DESCRIPTION
This way WSL is able to find reg.exe even is the WSL interoperation with Windows is disabled in /etc/wsl.conf

[interop]
appendWindowsPath = false

