### PR TITLE
Global option for setting a transparent background on dark themes

### DIFF
--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -13,6 +13,9 @@ local set_light_mode
 ---@type number
 local update_interval
 
+---@type boolean
+local transparent_dark_background
+
 ---@type table
 local query_command
 ---@type "Linux" | "Darwin" | "Windows_NT" | "WSL"
@@ -47,6 +50,13 @@ local function parse_query_response(res)
 	return false
 end
 
+local function set_transparent_dark_background()
+  vim.cmd([[highlight Normal guibg=none]])
+  vim.cmd([[highlight NonText guibg=none]])
+  vim.cmd([[highlight Normal ctermbg=none]])
+  vim.cmd([[highlight NonText ctermbg=none]])
+end
+
 ---@param callback fun(is_dark_mode: boolean)
 local function check_is_dark_mode(callback)
 	utils.start_job(query_command, {
@@ -66,6 +76,9 @@ local function change_theme_if_needed(is_dark_mode)
 	is_currently_dark_mode = is_dark_mode
 	if is_currently_dark_mode then
 		set_dark_mode()
+    if transparent_dark_background then
+      set_transparent_dark_background()
+    end
 	else
 		set_light_mode()
 	end
@@ -186,6 +199,7 @@ local function setup(options)
 	end
 	update_interval = options.update_interval or 3000
 	fallback = options.fallback or "dark"
+  transparent_dark_background = options.transparent_dark_background or false
 
 	init()
 end

--- a/lua/auto-dark-mode/types.lua
+++ b/lua/auto-dark-mode/types.lua
@@ -8,3 +8,5 @@
 -- Optional. Fallback theme to use if the system theme can't be detected.
 -- Useful for linux and environments without a desktop manager.
 ---@field fallback "light" | "dark" | nil
+--- Optional: If not provided, false will be used, default for solid background color
+---@field transparent_dark_background boolean?


### PR DESCRIPTION
Global option for setting a transparent background on dark themes, useful if you like to set your terminal window with some degree of transparency. The boolean variable exposed to the user is:

transparent_dark_background

If is set to true, the transparent background will be applied to the dark theme, if is set to false, or not setted at all, then the background will be set to the default solid color.