### PR TITLE
Support custom query_command

### DIFF
--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -95,7 +95,7 @@ local function init()
       if system == "Darwin" then
           query_command = { "defaults", "read", "-g", "AppleInterfaceStyle" }
       elseif system == "Linux" then
-          if query_command == nil and vim.fn.executable("dbus-send") then
+          if vim.fn.executable("dbus-send") then
               error([[
           `dbus-send` is not available. The Linux implementation of
           auto-dark-mode.nvim relies on `dbus-send` being on the `$PATH`.

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -95,7 +95,7 @@ local function init()
       if system == "Darwin" then
           query_command = { "defaults", "read", "-g", "AppleInterfaceStyle" }
       elseif system == "Linux" then
-          if vim.fn.executable("dbus-send") then
+          if not vim.fn.executable("dbus-send") then
               error([[
           `dbus-send` is not available. The Linux implementation of
           auto-dark-mode.nvim relies on `dbus-send` being on the `$PATH`.

--- a/lua/auto-dark-mode/types.lua
+++ b/lua/auto-dark-mode/types.lua
@@ -8,3 +8,7 @@
 -- Optional. Fallback theme to use if the system theme can't be detected.
 -- Useful for linux and environments without a desktop manager.
 ---@field fallback "light" | "dark" | nil
+-- Optional. If provided, will override the query command used to determine the theme preference
+---@field query_command table | nil
+-- Optional. If provided, will be used to match against the provided query_command. Required if query_command is not nil
+---@field dark_theme_match string | nil


### PR DESCRIPTION
Been using this project for a long time, but my `i3` setup does not set `org.freedesktop.appearance.color-scheme` and getting it to has proven trickier than expected. Initially my goal was to add support for the [GTK Dark Theme Variant](https://wiki.archlinux.org/title/GTK#Dark_theme_variant) but thought perhaps something more inclusive of any wacky local setup might be better. 

This PR aims to add an entry point to overwrite the `query_command` with a custom command, to be matched against the `dark_theme_match`, which will then toggle the theme accordingly. This is just a first pass, open to any feedback.