### PR TITLE
fix: increase dbus-send reply timeout

### DIFF
--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -74,7 +74,7 @@ M.init = function()
 			"dbus-send",
 			"--session",
 			"--print-reply=literal",
-			"--reply-timeout=1000",
+			"--reply-timeout=5000",
 			"--dest=org.freedesktop.portal.Desktop",
 			"/org/freedesktop/portal/desktop",
 			"org.freedesktop.portal.Settings.Read",


### PR DESCRIPTION
it fixes an error "Error org.freedesktop.DBus.Error.NoReply: Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken."

it is potentially fix for:
- https://github.com/f-person/auto-dark-mode.nvim/issues/56
- https://github.com/f-person/auto-dark-mode.nvim/issues/55