### PR TITLE
Fix validate backwards compatibility

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,7 +2,7 @@ name: Run Tests
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
   push:
     branches: [master]
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,7 +1,8 @@
 name: Run Tests
 
-on: 
-  pull_request: {}
+on:
+  pull_request:
+    types: [opened, edited]
   push:
     branches: [master]
 
@@ -16,7 +17,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        neovim_version: 
+        neovim_version:
           - v0.7.2
           - v0.8.3
           - v0.9.5

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -19,19 +19,29 @@ local default_options = {
 
 ---@param options AutoDarkModeOptions
 local function validate_options(options)
-	vim.validate({
-		fallback = {
-			options.fallback,
-			function(opt)
-				return vim.tbl_contains({ "dark", "light" }, opt)
-			end,
-			"`fallback` to be either 'light' or 'dark'",
-		},
-		set_dark_mode = { options.set_dark_mode, "function" },
-		set_light_mode = { options.set_light_mode, "function" },
-		update_interval = { options.update_interval, "number" },
-	})
+	local version = vim.version()
 
+	if (version.major == 0 and version.minor >= 11) or version.major > 0 then
+		vim.validate("fallback", options.fallback, function(opt)
+			return vim.tbl_contains({ "dark", "light" }, opt)
+		end, "`fallback` to be either 'light' or 'dark'")
+		vim.validate("set_dark_mode", options.set_dark_mode, "function")
+		vim.validate("set_light_mode", options.set_light_mode, "function")
+		vim.validate("update_interval", options.update_interval, "number")
+	else
+		vim.validate({
+			fallback = {
+				options.fallback,
+				function(opt)
+					return vim.tbl_contains({ "dark", "light" }, opt)
+				end,
+				"`fallback` to be either 'light' or 'dark'",
+			},
+			set_dark_mode = { options.set_dark_mode, "function" },
+			set_light_mode = { options.set_light_mode, "function" },
+			update_interval = { options.update_interval, "number" },
+		})
+	end
 	M.state.setup_correct = true
 end
 


### PR DESCRIPTION
This PR fixes a backwards compatibility issue introduced in #60 .
Additionally it enabled PR unit-test validation mentioned in https://github.com/f-person/auto-dark-mode.nvim/pull/60#issuecomment-2994451802